### PR TITLE
wtp.c: Drop the static get_border declaration

### DIFF
--- a/wtp.c
+++ b/wtp.c
@@ -25,7 +25,6 @@ static xcb_connection_t *conn;
 
 static void usage      (char *name);
 static void teleport   (xcb_window_t, int, int, int, int);
-static  int get_border (xcb_window_t win);
 
 static void
 usage(char *name)


### PR DESCRIPTION
get_border() was removed earlier, drop the declaration to silence a compiler warning.
