### PR TITLE
watter.c: Use size_t to silence a compiler warning

### DIFF
--- a/wattr.c
+++ b/wattr.c
@@ -57,7 +57,7 @@ getattribute(xcb_window_t w, int attr)
 int
 main(int argc, char **argv)
 {
-	int i,c;
+	size_t i,c;
 	xcb_window_t w = 0;
 
 	if (argc < 2 || (strncmp(argv[1], "-h", 2) == 0)) {


### PR DESCRIPTION
When compiled with -Wextra (or -Wsign-compare), we get a warning, because strlen() returns size_t (usually unsigned), not int. Just use a size_t to avoid that.
