### PR TITLE
Fix wrs absolute mode

### DIFF
--- a/wrs.c
+++ b/wrs.c
@@ -42,8 +42,8 @@ resize(xcb_window_t w, int mode, int x, int y)
 		return;
 
 	if (mode == ABSOLUTE) {
-		x -= r->x + r->width;
-		y -= r->y + r->height;
+		x -= r->width;
+		y -= r->height;
 	}
 
 	if ((r->x + r->width + 2*r->border_width + x) > scr->width_in_pixels)

--- a/wrs.c
+++ b/wrs.c
@@ -28,10 +28,9 @@ usage(char *name)
 static void
 resize(xcb_window_t w, int mode, int x, int y)
 {
-	uint32_t val[3];
+	uint32_t val[2];
 	uint32_t mask = XCB_CONFIG_WINDOW_WIDTH
-	              | XCB_CONFIG_WINDOW_HEIGHT
-	              | XCB_CONFIG_WINDOW_STACK_MODE;
+	              | XCB_CONFIG_WINDOW_HEIGHT;
 	xcb_get_geometry_cookie_t c;
 	xcb_get_geometry_reply_t *r;
 
@@ -56,7 +55,6 @@ resize(xcb_window_t w, int mode, int x, int y)
 
 	val[0] = r->width  + x;
 	val[1] = r->height + y;
-	val[2] = XCB_STACK_MODE_ABOVE;
 
 	xcb_configure_window(conn, w, mask, val);
 


### PR DESCRIPTION
Fixes #33 

The problem is that absolute mode in `wrs` did this: (Variable names are pseudo code)

```
x = param_new_width; // parameter, not actually in code
y = param_new_height; // parameter, not actually in code

x -= r->x + r->width;
y -= r->y + r->height;

new_width = r->width  + x;
new_width = r->height + y;
```

which can be simplified to this:

```
new_width = r->width - r->width - r->x + param_new_width;
new_height = r->height - r->height - r->y + param_new_height;
```

In relative mode this is like this (which makes sense):

```
new_width = r->width + resize_by_x;
new_height = r->height + resize_by_y;
```

The correct absolute mode would look like this:

```
new_width = r->width - r->width + param_new_width;
new_height = r->height - r->height + param_new_height;
```

As you can see, the old width/height cancels out.

This makes `wrs` behave properly when used in absolute mode.