### PR TITLE
Fix the problem of minus numerical values being used as arguments

### DIFF
--- a/man/wmp.1
+++ b/man/wmp.1
@@ -26,7 +26,9 @@ variable.
 .Pp
 .Dl $ wmp -a $(wattr xy $(pfw))
 .Pp
-.Dl $ wmp -r -100 0
+.Dl $ wmp -r 100 0
+.Pp
+.Dl $ wmp -r -- -100 0
 .Pp
 .Dl $ wmp 0x01600006
 .Dl 311 49


### PR DESCRIPTION
A fix for issue #41 by rejecting every switch which is not immediately followed by a letter.