### PR TITLE
pfw: return 1 if no window is focused

### DIFF
--- a/pfw.c
+++ b/pfw.c
@@ -25,6 +25,10 @@ focus_window(void)
 
 	w = r->focus;
 	free(r);
+
+	if (w == XCB_NONE || w == XCB_INPUT_FOCUS_POINTER_ROOT)
+		errx(1, "focus not set");
+
 	return w;
 }
 


### PR DESCRIPTION
When no window is focused X returns strange window 1 result to pfw which doesn't check it and outputs 0x00000001 returning status 0 in such case. This is confusing and leads to mistakes. My opinion is pfw should output nothing and return status 1 so it can be gracefully checked by caller.

E.g. 'xdotool getwindowfocus' behaves this way.