### PR TITLE
Chwb fix for live border size changing

### DIFF
--- a/chwso.c
+++ b/chwso.c
@@ -32,7 +32,7 @@ main(int argc, char **argv)
 	xcb_window_t win;
 	uint32_t values[1];
 	char *argv0 = NULL;
-	
+
 	if (argc != 3)
 		usage(argv[0]);
 


### PR DESCRIPTION
As of now, chwb changes border size in with a standard xcb call, which ends up displacing the application portion of a window down the screen by the change in border width. This makes any type of live border resizing impractical because it's hard to read moving text.
This PR fixes this with an X-Y offset in the same XCB call.
It also removes some trailing whitespace in an unrelated file that was driving me crazy.