### PR TITLE
docs: fix simple typo, varialbes -> variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ System-wide installation (default PREFIX is `/usr`):
     $ make
     # make install
 
-Here are the varialbes you can override, along with their default values:
+Here are the variables you can override, along with their default values:
 
     CC         =  cc
     LD         =  $(CC)


### PR DESCRIPTION
There is a small typo in README.md.

Should read `variables` rather than `varialbes`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md